### PR TITLE
Rewording README.zh-Hans.md

### DIFF
--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -24,13 +24,13 @@
   <script src="//cdn.jsdelivr.net/npm/spacingjs" defer></script>
   ```
 
-2. 将游标移动在一个元素上，然后按下 <kbd>Alt</kbd> 键（Windows）或 <kbd>⌥ Option</kbd> 键（Mac）。
+2. 将鼠标移动到一个元素上，然后按下 <kbd>Alt</kbd> 键（Windows）或 <kbd>⌥ Option</kbd> 键（Mac）。
 
-3. 将游标移动到其他元素上，即会显示相关的测量结果。
+3. 将鼠标移动到其他元素上，就会显示相关的测量结果。
 
 ## 参与开发
 
-欢迎 Fork 这个 Repo 进行开发，并提交 Pull Requests。在 [GitHub Issues](https://github.com/stevenlei/spacingjs/issues) 回报 Bug，在 [GitHub Discussions](https://github.com/stevenlei/spacingjs/discussions) 讨论功能／想法／问题。
+欢迎 Fork 这个 Repo 进行开发，并提交 Pull Requests。在 [GitHub Issues](https://github.com/stevenlei/spacingjs/issues) 汇报 Bug，在 [GitHub Discussions](https://github.com/stevenlei/spacingjs/discussions) 讨论功能／想法／问题。
 
 ## 授权协议
 


### PR DESCRIPTION
几个地方说明一下：
* Cursor。对译角度来说是“光标"（具体请见维基百科），这里直接说”鼠标“，或者说”鼠标指针“都可以，不用游标。
* 繁体一般写作「回報錯誤」，而简体的此用法一般写作“汇报错误”或者“汇报漏洞”。相关的包括feedback（「意見回饋」之于“意见反馈”）。
* 修改了一些粤语用法。

还有一个很有趣的一点。目前`README.zh-Hant.md`里面使用了「文檔」一词；而在zh-tw下，documentation一般写作「文件」（不同于file，file为「檔案」）。同样，load在zh-tw下一般写作「載入」。由于我不那么熟悉繁体使用者的实际写法，这里我就不再pr了。当然啦，`zh-Hant`不表明任何地区，所以理论上不改是毫无问题的。