### PR TITLE
reset state if document lost focus

### DIFF
--- a/src/spacing.ts
+++ b/src/spacing.ts
@@ -33,7 +33,7 @@ function keyDownHandler(e: KeyboardEvent) {
   }
 }
 
-function keyUpHandler(e: KeyboardEvent) {
+function keyUpHandler(e?: KeyboardEvent) {
   active = false;
 
   clearPlaceholderElement('selected');
@@ -48,6 +48,8 @@ function keyUpHandler(e: KeyboardEvent) {
 }
 
 function cursorMovedHandler(e: MouseEvent) {
+  !document.hasFocus() && keyUpHandler()
+  
   if (!active) return;
 
   setTargetElement().then(() => {


### PR DESCRIPTION
fix use `alt + tab` to switch application not trigger `keyup` event #10 